### PR TITLE
Track Report ID presence in HID report descriptors

### DIFF
--- a/Class/HID/usbh_hid.h
+++ b/Class/HID/usbh_hid.h
@@ -522,6 +522,7 @@ typedef  struct  usbh_hid_dev {
     CPU_INT08U           NbrAppColl;                            /* Nbr of app coll in main item.                        */
     USBH_HID_APP_COLL    AppColl[USBH_HID_CFG_MAX_NBR_APP_COLL];/* App coll in main item.                               */
     CPU_INT08U           NbrReportID;                           /* Tot nbr of report ID.                                */
+    CPU_BOOLEAN          IsReportID_Present;                    /* Indicate if report ID tag is present.                */
 
                                                                 /* Report ID of all colls.                              */
     USBH_HID_REPORT_ID   ReportID[USBH_HID_CFG_MAX_NBR_REPORT_ID];

--- a/Class/HID/usbh_hidparser.c
+++ b/Class/HID/usbh_hidparser.c
@@ -1038,6 +1038,9 @@ static  USBH_ERR  USBH_HID_AddReport (USBH_HID_DEV     *p_hid_dev,
 
                                                                 /* ----------------- INITIALIZE REPORT ---------------- */
     USBH_HID_InitReport(p_parser, p_report_new);
+    if (p_report_new->ReportID != 0u) {
+        p_hid_dev->IsReportID_Present = DEF_TRUE;
+    }
 
                                                                 /* ------------------ VALIDATE REPORT ----------------- */
     err = USBH_HID_ValidateReport(p_report_new);


### PR DESCRIPTION
This PR adds support for keeping track of whether or not a HID device provides Report ID items in the report descriptors. This is important as many times callers need to prepend an identifier prefix to transfers based on if a Report ID was specified.

This is inline with the HID 1.11 specification (see Section 5.6):

> If no Report ID item tags are present in the Report descriptor, it can be assumed that only one Input, Output, and Feature report structure exists and together they represent all of the device’s data.