### PR TITLE
Fix race condition in USBH_HC_Stop

### DIFF
--- a/Source/usbh_core.c
+++ b/Source/usbh_core.c
@@ -747,8 +747,8 @@ USBH_ERR  USBH_HC_Stop (CPU_INT08U  hc_nbr)
     p_hc     = &USBH_Host.HC_Tbl[hc_nbr];
     p_rh_dev =  p_hc->HC_Drv.RH_DevPtr;
 
-    USBH_DevDisconn(p_rh_dev);                                  /* Disconn RH dev.                                      */
     USBH_HCD_Stop(p_hc, &err);
+    USBH_DevDisconn(p_rh_dev);                                  /* Disconn RH dev.                                      */
 
     return (err);
 }


### PR DESCRIPTION
This PR fixes a race condition present in `USBH_HC_Stop` where the host controller can wedge if data is received after `USBH_DevDisconn` completes, but before `USBH_HCD_Stop` is called. These changes ensure the host controller driver has disabled interrupts and is quiesced prior to unloading class drivers.