### PR TITLE
CDC ProbeDev to support multiple cfg and alt if

### DIFF
--- a/Class/CDC/usbh_cdc.h
+++ b/Class/CDC/usbh_cdc.h
@@ -306,6 +306,7 @@ typedef  struct  usbh_cdc_dev {
     USBH_EP           DIC_BulkIn;
     USBH_EP           DIC_BulkOut;
 
+    CPU_INT08U        Cfg_Nbr;
     USBH_IF          *CIC_IF_Ptr;
     CPU_INT08U        CIC_IF_Nbr;
     USBH_IF          *DIC_IF_Ptr;


### PR DESCRIPTION
# Summary of change

* This updates `USBH_CDC_ProbeDev` to loop through all the configurations of the device, as well as checks for alternate interfaces for CDC data.
* It also allows device to report class at interface
* Adds attribute to CDC dev to be able to retrieve the CDC configuration.

# Validation

Validated with a few CDC devices, was able to transfer data without issues.