### PR TITLE
Changed ECM event callback to re-register every time + timeout support for data tx

### DIFF
--- a/App/CDC/app_usbh_cdc_ecm.c
+++ b/App/CDC/app_usbh_cdc_ecm.c
@@ -309,7 +309,7 @@ static  void  App_USBH_ECM_DevConn (USBH_CDC_DEV  *p_cdc_dev)
         App_USBH_ECM_MACAddr[i] += Str_ParseNbr_Int32U((CPU_CHAR *)&App_USBH_ECM_Ptr->MAC_Addr[2 * i + 1], DEF_NULL, 16);
     }
 
-    USBH_CDC_ECM_EventRxNotifyReg(App_USBH_ECM_Ptr, App_USBH_ECM_EventNotify, DEF_NULL);
+    USBH_CDC_ECM_EventRxAsync(App_USBH_ECM_Ptr, App_USBH_ECM_EventNotify, DEF_NULL);
 }
 
 
@@ -340,7 +340,7 @@ static  void  App_USBH_ECM_DevDisconn (USBH_CDC_DEV  *p_cdc_dev)
 *
 * Description : This function is called when CDC ECM event occurs.
 *
-* Argument(s) : p_args        Pointer to arguments passed to USBH_CDC_ECM_EventRxNotifyReg
+* Argument(s) : p_args        Pointer to arguments passed to USBH_CDC_ECM_EventRxAsync
 *
 *               ecm_state     State of the CDC ECM device.
 *
@@ -369,7 +369,10 @@ static  void  App_USBH_ECM_EventNotify(void                *p_arg,
             App_USBH_ECM_StartedRxData = DEF_TRUE;
         }
     }
+
+    USBH_CDC_ECM_EventRxAsync(App_USBH_ECM_Ptr, App_USBH_ECM_EventNotify, DEF_NULL);
 }
+
 
 /*
 *********************************************************************************************************

--- a/Class/CDC/ECM/usbh_ecm.h
+++ b/Class/CDC/ECM/usbh_ecm.h
@@ -130,16 +130,22 @@ typedef  struct  usbh_cdc_ecm_dev {
 *********************************************************************************************************
 */
 
-USBH_ERR           USBH_CDC_ECM_GlobalInit      (void);
+USBH_ERR           USBH_CDC_ECM_GlobalInit  (void);
 
-USBH_ERR           USBH_CDC_ECM_EventRxNotifyReg(USBH_CDC_ECM_DEV           *p_cdc_ecm_dev,
-                                                 USBH_CDC_ECM_EVENT_NOTIFY   p_ecm_event_notify,
-                                                 void                       *p_arg);
+USBH_ERR           USBH_CDC_ECM_EventRxAsync(USBH_CDC_ECM_DEV           *p_cdc_ecm_dev,
+                                             USBH_CDC_ECM_EVENT_NOTIFY   p_ecm_event_notify,
+                                             void                       *p_arg);
 
-USBH_CDC_ECM_DEV  *USBH_CDC_ECM_Add             (USBH_CDC_DEV               *p_cdc_dev,
-                                                 USBH_ERR                   *p_err);
+CPU_INT32U         USBH_CDC_ECM_DataTx      (USBH_CDC_ECM_DEV           *p_cdc_ecm_dev,
+                                             CPU_INT08U                 *p_buf,
+                                             CPU_INT32U                  buf_len,
+                                             CPU_INT32U                  timeout_ms,
+                                             USBH_ERR                   *p_err);
 
-USBH_ERR           USBH_CDC_ECM_Remove          (USBH_CDC_ECM_DEV           *p_cdc_ecm_dev);
+USBH_CDC_ECM_DEV  *USBH_CDC_ECM_Add         (USBH_CDC_DEV               *p_cdc_dev,
+                                             USBH_ERR                   *p_err);
+
+USBH_ERR           USBH_CDC_ECM_Remove      (USBH_CDC_ECM_DEV           *p_cdc_ecm_dev);
 
 
 /*


### PR DESCRIPTION
## Overview

Changed `USBH_CDC_ECM_EventRxNotifyReg` to `USBH_CDC_ECM_EventRxAsync` to allow re-registration of CDC event callbacks. This way the OS is not notified if the application is not ready to receive data.
Added `USBH_CDC_ECM_DataTx` (previously relied on `USBH_CDC_DataTx`) which allows more control over data transfers (e.g. timeouts). Since ECM carries ethernet frames, this allow the application to make more decisions on communication failures (e.g. drop a packet on timeout).

## Summary of change

* Rename `USBH_CDC_ECM_EventRxNotifyReg` to `USBH_CDC_ECM_EventRxAsync` to register callback every time
* Added `USBH_CDC_ECM_DataTx`

## Validation

Tested on a couple ECM devices. Some devices send a lot of events, this new implementation allows to relieve some pressure on the CPU when needed.